### PR TITLE
Protect SECRET_KEY under .env

### DIFF
--- a/api/settings.py
+++ b/api/settings.py
@@ -11,6 +11,10 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+from dotenv import load_dotenv
+
+# Load env vars
+load_dotenv()
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -20,7 +24,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/1.11/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "(^t3vuq6j5%xmd)a#fy+-=zq)-btm757ddnwl55b_%4+xb7wz&"
+SECRET_KEY = os.environ.get("SECRET_KEY")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pylint==1.9.2
 pytz==2018.4
 six==1.11.0
 wrapt==1.10.11
+python-dotenv==0.14.0


### PR DESCRIPTION
In this PR, I introduce [`dotenv`](https://pypi.org/project/python-dotenv/l) as a way to protect sensitive information in the project such as the `SECRET_KEY`.